### PR TITLE
Added the walkthrough README output file and updated the video

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,14 +19,15 @@ ReadmeGen uses nodejs and the "inquirer" dependency package to prompt you for in
 
 1. Change the project's root directory  
 2. Install the dependency modules: npm install  
-![alt text](assets/images/screenshot.png)
+![ReadmeGen screenshot](assets/images/screenshot.png)
 
 ## Usage
 
 1. Run: node src/index.js  
 2. Answer the prompts  
 3. View the generated README.md  
-[Demonstration Video](https://drive.google.com/file/d/1g8EP_mkyd3oHk4iQe3Qgrvbv_yjhvNCx/view)
+* See the [ReadmeGen Walkthrough](https://drive.google.com/file/d/1LaERyMDhP6-J8q0OTHyf95QkQvJzfBkp/view)  
+* Here's the walkthrough [output](examples/README.md) file
 
 ## License
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,46 @@
+
+# MyProject [![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](https://opensource.org/licenses/MPL-2.0)
+
+## Description
+
+MyProject helps automate a task to avoid manual errors
+
+## Table of Contents
+
+- [Installation](#installation)
+- [Usage](#usage)
+- [License](#license)
+- [Contributing](#contributing)
+- [Tests](#tests)
+- [Questions](#questions)
+
+
+## Installation
+
+1. Change to the directory containing package.json  
+2. Install the dependency packages: npm -i
+
+## Usage
+
+1. Run the app: node src/index.js  
+2. Read the instructions.  
+3. Answer the prompts
+
+## License
+
+This application is covered under the [Mozilla Public License 2.0](https://opensource.org/licenses/MPL-2.0) license
+
+## Contributing
+
+Follow best coding practices. Be sure to include commit messages and use a succinct explanation
+
+## Tests
+
+Tests are located in tests/ . To run a test: node tests/testscriptname.js
+
+## Questions
+
+If you have any questions, feel free to reach out: 
+- GitHub: [joeuser](https://github.com/joeuser)  
+- Email: joeuser@gmail.com
+

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,8 @@ ReadmeGen
 Welcome to ReadmeGen! You will receive several prompts for 
 information that will be used to dynamically generate a 
 professional README.md file that you can include with your 
-source control repository.
+source control repository. Use double-spaces to indicate
+line breaks.
 `;
 
 // Default answers for testing and debugging
@@ -34,8 +35,8 @@ if (DEBUG) {
     defaultAnswers = [
         'ReadmeGen',
         'ReadmeGen uses nodejs and the "inquirer" dependency package to prompt you for information used to generate a README.md file for your GitHub project.',
-        '1. Change the project\'s root directory  2. Install the dependency modules: npm install  ![alt text](assets/images/screenshot.png)',
-        '1. Run: node src/index.js  2. Answer the prompts  3. View the generated README.md  [Demonstration Video](https://drive.google.com/file/d/1g8EP_mkyd3oHk4iQe3Qgrvbv_yjhvNCx/view)',
+        '1. Change the project\'s root directory  2. Install the dependency modules: npm install  ![ReadmeGen screenshot](assets/images/screenshot.png)',
+        '1. Run: node src/index.js  2. Answer the prompts  3. View the generated README.md  * See the [ReadmeGen Walkthrough](https://drive.google.com/file/d/1LaERyMDhP6-J8q0OTHyf95QkQvJzfBkp/view)  * Here\'s the walkthrough [output](examples/README.md) file',
         'mit',
         'Guidelines:  Ensure your code follows the project\'s coding standards.  Write clear and concise commit messages.  If your changes include new features, please update the documentation accordingly.  If you are fixing a bug, please include a test to verify the fix.  Thank you for your contributions!',
         'Test instructions:  1. Try generating a README with license, and another that has no license (select None).  2. For the contact questions try these account entry combinations: both, neither, github only, email only',


### PR DESCRIPTION
* I missed capturing the output README from the walkthrough: checked it in under examples/, updated the video (and link).
* Also mentioned the double-space convention for newlines in the CLI description to make it more friendly